### PR TITLE
Fix invalidated linked entities in node graph

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4068,6 +4068,10 @@ void CBasePlayer::UpdateClientData()
 	//Handled anything that needs resetting
 	m_bRestored = false;
 	
+	// in the event that the player JUST spawned, and the level node graph
+	// was loaded, fix all of the node graph pointers before the game starts.
+
+	// !!!BUGBUG - now that we have multiplayer, this needs to be moved!
 	if (0 != WorldGraph.m_fGraphPresent && 0 == WorldGraph.m_fGraphPointersSet)
 	{
 		if (!WorldGraph.FSetGraphPointers())

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -2848,22 +2848,6 @@ void CBasePlayer::Spawn()
 
 void CBasePlayer::Precache()
 {
-	// in the event that the player JUST spawned, and the level node graph
-	// was loaded, fix all of the node graph pointers before the game starts.
-
-	// !!!BUGBUG - now that we have multiplayer, this needs to be moved!
-	if (0 != WorldGraph.m_fGraphPresent && 0 == WorldGraph.m_fGraphPointersSet)
-	{
-		if (!WorldGraph.FSetGraphPointers())
-		{
-			ALERT(at_console, "**Graph pointers were not set!\n");
-		}
-		else
-		{
-			ALERT(at_console, "**Graph Pointers Set!\n");
-		}
-	}
-
 	// SOUNDS / MODELS ARE PRECACHED in ClientPrecache() (game specific)
 	// because they need to precache before any clients have connected
 
@@ -4083,6 +4067,18 @@ void CBasePlayer::UpdateClientData()
 
 	//Handled anything that needs resetting
 	m_bRestored = false;
+	
+	if (0 != WorldGraph.m_fGraphPresent && 0 == WorldGraph.m_fGraphPointersSet)
+	{
+		if (!WorldGraph.FSetGraphPointers())
+		{
+			ALERT(at_console, "**Graph pointers were not set!\n");
+		}
+		else
+		{
+			ALERT(at_console, "**Graph Pointers Set!\n");
+		}
+	}
 }
 
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1781,6 +1781,22 @@ void CBasePlayer::PreThink()
 			SET_VIEW(edict(), viewEntity->edict());
 		}
 	}
+	
+	// in the event that the player JUST spawned, and the level node graph
+	// was loaded, fix all of the node graph pointers before the game starts.
+
+	// !!!BUGBUG - now that we have multiplayer, this needs to be moved!
+	if (0 != WorldGraph.m_fGraphPresent && 0 == WorldGraph.m_fGraphPointersSet)
+	{
+		if (!WorldGraph.FSetGraphPointers())
+		{
+			ALERT(at_console, "**Graph pointers were not set!\n");
+		}
+		else
+		{
+			ALERT(at_console, "**Graph Pointers Set!\n");
+		}
+	}
 
 	// JOHN: checks if new client data (for HUD and view control) needs to be sent to the client
 	UpdateClientData();
@@ -4067,22 +4083,6 @@ void CBasePlayer::UpdateClientData()
 
 	//Handled anything that needs resetting
 	m_bRestored = false;
-	
-	// in the event that the player JUST spawned, and the level node graph
-	// was loaded, fix all of the node graph pointers before the game starts.
-
-	// !!!BUGBUG - now that we have multiplayer, this needs to be moved!
-	if (0 != WorldGraph.m_fGraphPresent && 0 == WorldGraph.m_fGraphPointersSet)
-	{
-		if (!WorldGraph.FSetGraphPointers())
-		{
-			ALERT(at_console, "**Graph pointers were not set!\n");
-		}
-		else
-		{
-			ALERT(at_console, "**Graph Pointers Set!\n");
-		}
-	}
 }
 
 


### PR DESCRIPTION
Originally, Precache() would attempt to renew all linked entity pointers based on their stored model name, however since not all entities are initialized from a saved game during this stage yet, occasionally, the game would fail to renew linked ent pointers and therefore lose reference to doors (etc) that block a traversal path between nodes.

The change should ensure we relink referenced entity pointers at a time when all entities are already present, therefore we ensure references are still resolved correctly and the pathfinding continues to work correctly even after we load a saved game.

Previous behavior:
NPC would fail to navigate through doors on a loaded save.

Current behavior:
NPC has no issue navigating through doors on a loaded save.