### PR TITLE
Added missing tracerCount for EV_HLDM_FireBullets.

### DIFF
--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -478,7 +478,7 @@ void EV_FireGlock1(event_args_t* args)
 
 	VectorCopy(forward, vecAiming);
 
-	EV_HLDM_FireBullets(idx, forward, right, up, 1, vecSrc, vecAiming, 8192, BULLET_PLAYER_9MM, 0, 0, args->fparam1, args->fparam2);
+	EV_HLDM_FireBullets(idx, forward, right, up, 1, vecSrc, vecAiming, 8192, BULLET_PLAYER_9MM, 0, &tracerCount[idx - 1], args->fparam1, args->fparam2);
 }
 
 void EV_FireGlock2(event_args_t* args)
@@ -777,7 +777,7 @@ void EV_FirePython(event_args_t* args)
 
 	VectorCopy(forward, vecAiming);
 
-	EV_HLDM_FireBullets(idx, forward, right, up, 1, vecSrc, vecAiming, 8192, BULLET_PLAYER_357, 0, 0, args->fparam1, args->fparam2);
+	EV_HLDM_FireBullets(idx, forward, right, up, 1, vecSrc, vecAiming, 8192, BULLET_PLAYER_357, 0, &tracerCount[idx - 1], args->fparam1, args->fparam2);
 }
 //======================
 //	    PHYTON END


### PR DESCRIPTION
The two lines below do not pass `&tracerCount[idx - 1]` when calling `EV_HLDM_FireBullets`.

https://github.com/SamVanheer/halflife-updated/blob/c633af888fb276d9572dc77df328d7724a206ff2/cl_dll/ev_hldm.cpp#L481

https://github.com/SamVanheer/halflife-updated/blob/c633af888fb276d9572dc77df328d7724a206ff2/cl_dll/ev_hldm.cpp#L780

The code can crash with a null pointer exception if `iTracerFreq` different from 0 and `tracerCount` is unspecified.

https://github.com/SamVanheer/halflife-updated/blob/c633af888fb276d9572dc77df328d7724a206ff2/cl_dll/ev_hldm.cpp#L302

The changes pass `&tracerCount[idx - 1]` so that it will always point to a valid memory location.