### PR TITLE
Default implementation of HasTarget does not check the right variable.

### DIFF
--- a/dlls/cbase.h
+++ b/dlls/cbase.h
@@ -202,7 +202,7 @@ public:
 	virtual bool IsAlive() { return (pev->deadflag == DEAD_NO) && pev->health > 0; }
 	virtual bool IsBSPModel() { return pev->solid == SOLID_BSP || pev->movetype == MOVETYPE_PUSHSTEP; }
 	virtual bool ReflectGauss() { return (IsBSPModel() && !pev->takedamage); }
-	virtual bool HasTarget(string_t targetname) { return FStrEq(STRING(targetname), STRING(pev->targetname)); }
+	virtual bool HasTarget(string_t targetname) { return FStrEq(STRING(targetname), STRING(pev->target)); }
 	virtual bool IsInWorld();
 	virtual bool IsPlayer() { return false; }
 	virtual bool IsNetClient() { return false; }


### PR DESCRIPTION
See ValveSoftware/halflife#3083.