### PR TITLE
Fix func_tanks not being usable

### DIFF
--- a/dlls/func_tank.cpp
+++ b/dlls/func_tank.cpp
@@ -1022,7 +1022,7 @@ void CFuncTankControls::Think()
 	do
 	{
 		pTarget = FIND_ENTITY_BY_TARGETNAME(pTarget, STRING(pev->target));
-	} while (!FNullEnt(pTarget) && 0 == strncmp(STRING(pTarget->v.classname), "func_tank", 9));
+	} while (!FNullEnt(pTarget) && 0 != strncmp(STRING(pTarget->v.classname), "func_tank", 9));
 
 	if (FNullEnt(pTarget))
 	{


### PR DESCRIPTION
Friend of mine been using a mod that's based on this codebase, and he noticed that turrets/cannons stopped working. I found out that it's just a silly typo during one of the big refactorings.