### PR TITLE
Fix STL Algorithm Header Errors When Included with Platform.h

### DIFF
--- a/common/Platform.h
+++ b/common/Platform.h
@@ -77,4 +77,5 @@ using qboolean = int;
 #define V_min(a, b) (((a) < (b)) ? (a) : (b))
 #define V_max(a, b) (((a) > (b)) ? (a) : (b))
 
-#define clamp(val, min, max) (((val) > (max)) ? (max) : (((val) < (min)) ? (min) : (val)))
+// Clamp macro is deprecated. Use std::clamp instead.
+// #define clamp(val, min, max) (((val) > (max)) ? (max) : (((val) < (min)) ? (min) : (val)))

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3905,7 +3905,7 @@ void CBasePlayer::UpdateClientData()
 
 	if (pev->health != m_iClientHealth)
 	{
-		int iHealth = std::clamp(pev->health, 0.f, (float)(std::numeric_limits<short>::max())); // make sure that no negative health values are sent
+		int iHealth = std::clamp<float>(pev->health, 0.f, (float)(std::numeric_limits<short>::max())); // make sure that no negative health values are sent
 		if (pev->health > 0.0f && pev->health <= 1.0f)
 			iHealth = 1;
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -21,6 +21,7 @@
 */
 
 #include <limits>
+#include <algorithm>
 
 #include "extdll.h"
 #include "util.h"
@@ -3904,7 +3905,7 @@ void CBasePlayer::UpdateClientData()
 
 	if (pev->health != m_iClientHealth)
 	{
-		int iHealth = clamp(pev->health, 0, std::numeric_limits<short>::max()); // make sure that no negative health values are sent
+		int iHealth = std::clamp(pev->health, 0.f, (float)(std::numeric_limits<short>::max())); // make sure that no negative health values are sent
 		if (pev->health > 0.0f && pev->health <= 1.0f)
 			iHealth = 1;
 


### PR DESCRIPTION
"clamp" macro of Platform.h conflicts with "std::clamp" of the STL algorithm header. So `#include <algorithm>` forces Platform.h included after itself. This commit fixes the issue