### PR TITLE
Fix weapon deploy animations on fast switching with user binds

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3088,7 +3088,9 @@ void CBasePlayer::SelectItem(const char* pstr)
 
 	if (m_pActiveItem)
 	{
+		m_pActiveItem->m_ForceSendAnimations = true;
 		m_pActiveItem->Deploy();
+		m_pActiveItem->m_ForceSendAnimations = false;
 		m_pActiveItem->UpdateItemInfo();
 	}
 }


### PR DESCRIPTION
To reproduce the issue bind gauss and crossbow to some buttons, e.g.
```
bind "j" "weapon_gauss"
bind "k" "weapon_crossbow"
```
Use the buttons to switch between weapons. It will have the same problem as `lastinv` (before the fix).