### PR TITLE
Add .vs folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vs/
+
 # Allow Half-Life-specific files that would otherwise be ignored
 !lib/public/game_controls.lib
 !lib/public/SDL2.lib


### PR DESCRIPTION
When I opened the project in VS 2022 it generated a bunch of working files in the .vs folder, these should be ignored.