### PR TITLE
Have clients select weapons by ID, rather than by name

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -372,7 +372,7 @@ void CHudAmmo::Think()
 	{
 		if (gpActiveSel != (WEAPON*)1)
 		{
-			ServerCmd(gpActiveSel->szName);
+			// ServerCmd(gpActiveSel->szName);
 			g_weaponselect = gpActiveSel->iId;
 		}
 
@@ -445,7 +445,7 @@ void WeaponsResource::SelectSlot(int iSlot, bool fAdvance, int iDirection)
 			WEAPON* p2 = GetNextActivePos(p->iSlot, p->iSlotPos);
 			if (!p2)
 			{ // only one active item in bucket, so change directly to weapon
-				ServerCmd(p->szName);
+				// ServerCmd(p->szName);
 				g_weaponselect = p->iId;
 				return;
 			}

--- a/cl_dll/hl/hl_baseentity.cpp
+++ b/cl_dll/hl/hl_baseentity.cpp
@@ -258,6 +258,9 @@ bool CBasePlayer::Restore(CRestore& restore) { return false; }
 void CBasePlayer::SelectNextItem(int iItem) {}
 bool CBasePlayer::HasWeapons() { return false; }
 void CBasePlayer::SelectPrevItem(int iItem) {}
+CBasePlayerItem* CBasePlayer::GetNamedPlayerItem(const char* pstr) { return nullptr; }
+CBasePlayerItem* CBasePlayer::GetPlayerItem(int iId) { return nullptr; }
+void CBasePlayer::SelectItem(CBasePlayerItem* pItem) {}
 bool CBasePlayer::FlashlightIsOn() { return false; }
 void CBasePlayer::FlashlightTurnOn() {}
 void CBasePlayer::FlashlightTurnOff() {}

--- a/cl_dll/hl/hl_weapons.cpp
+++ b/cl_dll/hl/hl_weapons.cpp
@@ -258,39 +258,6 @@ Vector CBaseEntity::FireBulletsPlayer(unsigned int cShots, Vector vecSrc, Vector
 
 /*
 =====================
-CBasePlayer::SelectItem
-
-  Switch weapons
-=====================
-*/
-void CBasePlayer::SelectItem(const char* pstr)
-{
-	if (!pstr)
-		return;
-
-	CBasePlayerItem* pItem = NULL;
-
-	if (!pItem)
-		return;
-
-
-	if (pItem == m_pActiveItem)
-		return;
-
-	if (m_pActiveItem)
-		m_pActiveItem->Holster();
-
-	m_pLastItem = m_pActiveItem;
-	m_pActiveItem = pItem;
-
-	if (m_pActiveItem)
-	{
-		m_pActiveItem->Deploy();
-	}
-}
-
-/*
-=====================
 CBasePlayer::Killed
 
 =====================

--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -546,11 +546,21 @@ void ClientCommand(edict_t* pEntity)
 	}
 	else if (FStrEq(pcmd, "use"))
 	{
-		player->SelectItem((char*)CMD_ARGV(1));
+		auto weapon = player->GetNamedPlayerItem((char*)CMD_ARGV(1));
+		
+		if (weapon != nullptr)
+		{
+			player->SelectItem(weapon);
+		}
 	}
 	else if (((pstr = strstr(pcmd, "weapon_")) != NULL) && (pstr == pcmd))
 	{
-		player->SelectItem(pcmd);
+		auto weapon = player->GetNamedPlayerItem(pcmd);
+
+		if (weapon != nullptr)
+		{
+			player->SelectItem(weapon);
+		}
 	}
 	else if (FStrEq(pcmd, "lastinv"))
 	{
@@ -1808,6 +1818,18 @@ void CmdStart(const edict_t* player, const struct usercmd_s* cmd, unsigned int r
 
 	if (!pl)
 		return;
+	
+	if (cmd->weaponselect != 0)
+	{
+		auto weapon = pl->GetPlayerItem(cmd->weaponselect);
+
+		if (weapon != nullptr)
+		{
+			pl->SelectItem(weapon);
+		}
+		
+		((usercmd_t*)cmd)->weaponselect = 0;
+	}
 
 	if (pl->pev->groupinfo != 0)
 	{

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3047,10 +3047,10 @@ void CBasePlayer::SelectNextItem(int iItem)
 	}
 }
 
-void CBasePlayer::SelectItem(const char* pstr)
+CBasePlayerItem* CBasePlayer::GetNamedPlayerItem(const char* pstr)
 {
 	if (!pstr)
-		return;
+		return nullptr;
 
 	CBasePlayerItem* pItem = NULL;
 
@@ -3063,18 +3063,46 @@ void CBasePlayer::SelectItem(const char* pstr)
 			while (pItem)
 			{
 				if (FClassnameIs(pItem->pev, pstr))
-					break;
+					return pItem;
+				
 				pItem = pItem->m_pNext;
 			}
 		}
-
-		if (pItem)
-			break;
 	}
 
+	return nullptr;
+}
+
+CBasePlayerItem* CBasePlayer::GetPlayerItem(int iId)
+{
+	if (iId <= WEAPON_NONE)
+		return nullptr;
+
+	CBasePlayerItem* pItem = NULL;
+
+	for (int i = 0; i < MAX_ITEM_TYPES; i++)
+	{
+		if (m_rgpPlayerItems[i])
+		{
+			pItem = m_rgpPlayerItems[i];
+
+			while (pItem)
+			{
+				if (pItem->m_iId == iId)
+					return pItem;
+				
+				pItem = pItem->m_pNext;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+void CBasePlayer::SelectItem(CBasePlayerItem* pItem)
+{
 	if (!pItem)
 		return;
-
 
 	if (pItem == m_pActiveItem)
 		return;

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -287,7 +287,9 @@ public:
 	void SelectPrevItem(int iItem);
 	void SelectNextItem(int iItem);
 	void SelectLastItem();
-	void SelectItem(const char* pstr);
+	CBasePlayerItem* GetNamedPlayerItem(const char* pstr);
+	CBasePlayerItem* GetPlayerItem(int iId);
+	void SelectItem(CBasePlayerItem* pItem);
 	void ItemPreFrame();
 	void ItemPostFrame();
 	void GiveNamedItem(const char* szName);

--- a/network/delta.lst
+++ b/network/delta.lst
@@ -222,7 +222,8 @@ usercmd_t none
 	DEFINE_DELTA( impact_index, DT_INTEGER, 6, 1.0 ),
 	DEFINE_DELTA( impact_position[0], DT_SIGNED | DT_FLOAT, 16, 8.0 ),
 	DEFINE_DELTA( impact_position[1], DT_SIGNED | DT_FLOAT, 16, 8.0 ),
-	DEFINE_DELTA( impact_position[2], DT_SIGNED | DT_FLOAT, 16, 8.0 )
+	DEFINE_DELTA( impact_position[2], DT_SIGNED | DT_FLOAT, 16, 8.0 ),
+	DEFINE_DELTA( weaponselect, DT_BYTE, 6, 1.0 )
 }
 
 weapon_data_t none


### PR DESCRIPTION
The `usercmd_t` struct has a `weaponselect` field, used in the weapon prediction code, to select weapons by ID. Being a part of the client's command struct, it can also be sent over the net. Using this instead of sending a `"weapon_"` command every time a client wants to change weapons should substantially reduce the number of string comparisons that the server has to handle in multiplayer. In `network/delta.lst`, I set it to be sent as 6 bits, as weapon IDs only go up to 64.

(I also removed the `SelectItem` definition on the client, as it seems to be dead code.)