### PR TITLE
Fix RPG being flagged as unusable while a rocket is loaded

### DIFF
--- a/dlls/rpg.cpp
+++ b/dlls/rpg.cpp
@@ -547,17 +547,6 @@ void CRpg::UpdateSpot()
 #endif
 }
 
-bool CRpg::IsUseable()
-{
-	// The client needs to fall through to WeaponIdle so check the ammo here.
-	if (m_pPlayer->ammo_rockets <= 0)
-	{
-		return false;
-	}
-
-	return CBasePlayerWeapon::IsUseable();
-}
-
 class CRpgAmmo : public CBasePlayerAmmo
 {
 	void Spawn() override

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -799,8 +799,6 @@ public:
 	void UpdateSpot();
 	bool ShouldWeaponIdle() override { return true; }
 
-	bool IsUseable() override;
-
 	CLaserSpot* m_pSpot;
 	bool m_fSpotActive;
 	int m_cActiveRockets; // how many missiles in flight from this launcher right now?


### PR DESCRIPTION
The RPG has a (redundant) `IsUsable` override that bypasses a clip check in the base class. In deathmatch, this causes the weapon to auto switch as though it were empty, even while a rocket is still loaded.