### PR TITLE
Fix breakable objects reflecting the Gauss Gun shot that breaks them

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -796,6 +796,14 @@ int CBreakable::DamageDecal(int bitsDamageType)
 	return CBaseEntity::DamageDecal(bitsDamageType);
 }
 
+bool CBreakable::ReflectGauss()
+{
+	if (IsBreakable())
+		return false;
+	
+	return CBaseEntity::ReflectGauss();
+}
+
 
 class CPushable : public CBreakable
 {
@@ -812,6 +820,8 @@ public:
 	int ObjectCaps() override { return (CBaseEntity::ObjectCaps() & ~FCAP_ACROSS_TRANSITION) | FCAP_CONTINUOUS_USE; }
 	bool Save(CSave& save) override;
 	bool Restore(CRestore& restore) override;
+
+	bool ReflectGauss() override;
 
 	inline float MaxSpeed() { return m_maxSpeed; }
 
@@ -1022,4 +1032,12 @@ bool CPushable::TakeDamage(entvars_t* pevInflictor, entvars_t* pevAttacker, floa
 		return CBreakable::TakeDamage(pevInflictor, pevAttacker, flDamage, bitsDamageType);
 
 	return true;
+}
+
+bool CPushable::ReflectGauss()
+{
+	if (!FBitSet(pev->spawnflags, SF_PUSH_BREAKABLE))
+		return true;
+	
+	return CBreakable::ReflectGauss();
 }

--- a/dlls/func_break.h
+++ b/dlls/func_break.h
@@ -63,6 +63,8 @@ public:
 	bool Save(CSave& save) override;
 	bool Restore(CRestore& restore) override;
 
+	bool ReflectGauss() override;
+
 	inline bool Explodable() { return ExplosionMagnitude() > 0; }
 	inline int ExplosionMagnitude() { return pev->impulse; }
 	inline void ExplosionSetMagnitude(int magnitude) { pev->impulse = magnitude; }


### PR DESCRIPTION
This is a very specific quirk that I discovered while testing other changes. The Gauss Gun will kill breakables, resulting in the `pev->takedamage` field being set to `0`. The `ReflectGauss` member is called after this occurs, which then checks the `pev->takedamage` field, finds that the breakable doesn't take damage and reflects the shot.

https://github.com/SamVanheer/halflife-updated/blob/master/dlls/gauss.cpp#L400
https://github.com/SamVanheer/halflife-updated/blob/master/dlls/gauss.cpp#L407

The new override members should always ensure the intended behavior.