### PR TITLE
Tell the client what objects are breakable so that Gauss Gun shots won't be visibly reflected

### DIFF
--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -209,7 +209,7 @@ char* EV_HLDM_DamageDecal(physent_t* pe)
 	static char decalname[32];
 	int idx;
 
-	if (pe->classnumber == 1)
+	if (FBitSet(pe->classnumber, kBrushGlass))
 	{
 		idx = gEngfuncs.pfnRandomLong(0, 2);
 		sprintf(decalname, "{break%i", idx + 1);
@@ -934,7 +934,8 @@ void EV_FireGauss(event_args_t* args)
 
 			n = -DotProduct(tr.plane.normal, forward);
 
-			if (n < 0.5) // 60 degrees
+			// Move the breakable test down here so that decal effects are applied to breakable objects.
+			if (!FBitSet(pEntity->classnumber, kBrushBreakable) && n < 0.5) // 60 degrees
 			{
 				// ALERT( at_console, "reflect %f\n", n );
 				// reflect

--- a/common/const.h
+++ b/common/const.h
@@ -716,6 +716,12 @@ enum
 	kRenderFxLightMultiplier, //CTM !!!CZERO added to tell the studiorender that the value in iuser2 is a lightmultiplier
 };
 
+enum
+{
+	kBrushGlass = 1,
+	kBrushBreakable = 2,
+};
+
 #define _DEF_BYTE_
 
 typedef struct

--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -163,11 +163,16 @@ void CBreakable::Spawn()
 	m_angle = pev->angles.y;
 	pev->angles.y = 0;
 
+	if (IsBreakable())
+	{
+		pev->playerclass |= kBrushBreakable;
+	}
+
 	// HACK:  matGlass can receive decals, we need the client to know about this
 	//  so use class to store the material flag
 	if (m_Material == matGlass)
 	{
-		pev->playerclass = 1;
+		pev->playerclass |= kBrushGlass;
 	}
 
 	SET_MODEL(ENT(pev), STRING(pev->model)); //set size and link into world.

--- a/network/delta.lst
+++ b/network/delta.lst
@@ -127,7 +127,7 @@ entity_state_t gamedll Entity_Encode
 
 	// Playerclass signifies it's a decalable glass item when referring to an object
 
-	DEFINE_DELTA( playerclass, DT_INTEGER, 1, 1.0 )
+	DEFINE_DELTA( playerclass, DT_INTEGER, 2, 1.0 )
 }
 
 entity_state_player_t gamedll Player_Encode


### PR DESCRIPTION
This updates the "hack" to tell the client what objects are breakable glass by setting the `pev->playerclass` field. Constants have been defined to make it more clear what's going on. An extra bit is sent via `delta.lst` to flag objects as breakable and a check is performed in the weapon code for the Gauss Gun fire.