### PR TITLE
Fix items flashing for a frame when giving them

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3245,6 +3245,7 @@ static edict_t* GiveNamedItem_Common(entvars_t* pev, const char* pszName)
 		ALERT(at_console, "NULL Ent in GiveNamedItem!\n");
 		return nullptr;
 	}
+	VARS(pent)->effects |= EF_NODRAW;
 	VARS(pent)->origin = pev->origin;
 	pent->v.spawnflags |= SF_NORESPAWN;
 


### PR DESCRIPTION
When using `game_player_equip` (or anything that calls a `GiveNamedItem` variant) the items are spawned on the player origin, flashing in their view for a frame before being killed.  

The fix is simple, don't draw the items.