### PR TITLE
Don't let func_breakable take damage if it's set to Only Trigger

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -574,7 +574,8 @@ bool CBreakable::TakeDamage(entvars_t* pevInflictor, entvars_t* pevAttacker, flo
 	g_vecAttackDir = vecTemp.Normalize();
 
 	// do the damage
-	pev->health -= flDamage;
+	if (pev->takedamage)
+		pev->health -= flDamage;
 	if (pev->health <= 0)
 	{
 		Killed(pevAttacker, GIB_NORMAL);


### PR DESCRIPTION
Some attacks don't check for `pev->takedamage` and func_breakable doesn't check for it either.

Example map: [func_breakable.zip](https://github.com/user-attachments/files/16637086/func_breakable.zip)
