### PR TITLE
Entity event playback method

### DIFF
--- a/cl_dll/hl/hl_weapons.cpp
+++ b/cl_dll/hl/hl_weapons.cpp
@@ -318,6 +318,67 @@ void CBasePlayer::Spawn()
 	g_irunninggausspred = false;
 }
 
+void CBaseEntity::PlaybackEvent(
+	const unsigned short usEventIndex,
+	const float fparam1,
+	const float fparam2,
+	const int iparam1,
+	const int iparam2,
+	const int bparam1,
+	const int bparam2,
+	const int afFlags,
+	const bool bSendPosition,
+	const float flDelay)
+{
+	const float* origin = g_vecZero;
+	const float* angles = g_vecZero;
+
+	if (bSendPosition)
+	{
+		origin = pev->origin;
+		angles = pev->angles;
+	}
+
+	g_engfuncs.pfnPlaybackEvent(
+		afFlags,
+		edict(),
+		usEventIndex,
+		flDelay,
+		origin,
+		angles,
+		fparam1,
+		fparam2,
+		iparam1,
+		iparam2,
+		bparam1,
+		bparam2);
+}
+
+void CBasePlayer::PlaybackEvent(
+	const unsigned short usEventIndex,
+	const float fparam1,
+	const float fparam2,
+	const int iparam1,
+	const int iparam2,
+	const int bparam1,
+	const int bparam2,
+	const int afFlags,
+	const bool bSendPosition,
+	const float flDelay)
+{
+	CBaseEntity::PlaybackEvent(
+		usEventIndex,
+		fparam1,
+		fparam2,
+		iparam1,
+		iparam2,
+		bparam1,
+		bparam2,
+		afFlags,
+		bSendPosition || (afFlags & FEV_RELIABLE) != 0,
+		flDelay);
+}
+
 /*
 =====================
 UTIL_TraceLine

--- a/dlls/cbase.cpp
+++ b/dlls/cbase.cpp
@@ -792,6 +792,42 @@ int CBaseEntity::DamageDecal(int bitsDamageType)
 }
 
 
+void CBaseEntity::PlaybackEvent(
+	const unsigned short usEventIndex,
+	const float fparam1,
+	const float fparam2,
+	const int iparam1,
+	const int iparam2,
+	const int bparam1,
+	const int bparam2,
+	const int afFlags,
+	const bool bSendPosition,
+	const float flDelay)
+{
+	const float* origin = g_vecZero;
+	const float* angles = g_vecZero;
+
+	if (bSendPosition)
+	{
+		origin = pev->origin;
+		angles = pev->angles;
+	}
+
+	g_engfuncs.pfnPlaybackEvent(
+		afFlags,
+		edict(),
+		usEventIndex,
+		flDelay,
+		origin,
+		angles,
+		fparam1,
+		fparam2,
+		iparam1,
+		iparam2,
+		bparam1,
+		bparam2);
+}
+
 
 // NOTE: szName must be a pointer to constant memory, e.g. "monster_class" because the entity
 // will keep a pointer to it after this call.

--- a/dlls/cbase.h
+++ b/dlls/cbase.h
@@ -378,6 +378,18 @@ public:
 	int m_fInAttack;
 
 	int m_fireState;
+
+	virtual void PlaybackEvent(
+		const unsigned short usEventIndex,
+		const float fparam1 = 0.0F,
+		const float fparam2 = 0.0F,
+		const int iparam1 = 0,
+		const int iparam2 = 0,
+		const int bparam1 = 0,
+		const int bparam2 = 0,
+		const int afFlags = 0,
+		const bool bSendPosition = false,
+		const float flDelay = 0.0F);
 };
 
 inline bool FNullEnt(CBaseEntity* ent) { return (ent == NULL) || FNullEnt(ent->edict()); }

--- a/dlls/crossbow.cpp
+++ b/dlls/crossbow.cpp
@@ -322,14 +322,7 @@ void CCrossbow::FireSniperBolt()
 	m_pPlayer->m_iWeaponVolume = QUIET_GUN_VOLUME;
 	m_iClip--;
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usCrossbow2, 0.0, g_vecZero, g_vecZero, 0, 0, m_iClip, 0, 0, 0);
+	m_pPlayer->PlaybackEvent(m_usCrossbow2, 0.0F, 0.0F, m_iClip);
 
 	// player "shoot" animation
 	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
@@ -365,14 +358,7 @@ void CCrossbow::FireBolt()
 
 	m_iClip--;
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usCrossbow, 0.0, g_vecZero, g_vecZero, 0, 0, m_iClip, 0, 0, 0);
+	m_pPlayer->PlaybackEvent(m_usCrossbow, 0.0F, 0.0F, m_iClip);
 
 	// player "shoot" animation
 	m_pPlayer->SetAnimation(PLAYER_ATTACK1);

--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -179,9 +179,7 @@ bool CCrowbar::Swing(bool fFirst)
 
 	if (fFirst)
 	{
-		PLAYBACK_EVENT_FULL(FEV_NOTHOST, m_pPlayer->edict(), m_usCrowbar,
-			0.0, g_vecZero, g_vecZero, 0, 0, 0,
-			0.0, 0, 0.0);
+		m_pPlayer->PlaybackEvent(m_usCrowbar);
 	}
 
 

--- a/dlls/egon.cpp
+++ b/dlls/egon.cpp
@@ -158,13 +158,6 @@ void CEgon::Attack()
 	Vector vecAiming = gpGlobals->v_forward;
 	Vector vecSrc = m_pPlayer->GetGunPosition();
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
 	switch (m_fireState)
 	{
 	case FIRE_OFF:
@@ -178,7 +171,7 @@ void CEgon::Attack()
 
 		m_flAmmoUseTime = gpGlobals->time; // start using ammo ASAP.
 
-		PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usEgonFire, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, 0, m_fireMode, 1, 0);
+		m_pPlayer->PlaybackEvent(m_usEgonFire, 0.0F, 0.0F, 0, m_fireMode, 1);
 
 		m_shakeTime = 0;
 
@@ -198,7 +191,7 @@ void CEgon::Attack()
 
 		if (pev->fuser1 <= UTIL_WeaponTimeBase())
 		{
-			PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usEgonFire, 0, g_vecZero, g_vecZero, 0.0, 0.0, 0, m_fireMode, 0, 0);
+			m_pPlayer->PlaybackEvent(m_usEgonFire, 0.0F, 0.0F, 0, m_fireMode);
 			pev->fuser1 = 1000;
 		}
 
@@ -516,9 +509,9 @@ void CEgon::EndAttack()
 
 	if (m_fireState != FIRE_OFF) //Checking the button just in case!.
 		bMakeNoise = true;
-
-	PLAYBACK_EVENT_FULL(FEV_GLOBAL | FEV_RELIABLE, m_pPlayer->edict(), m_usEgonStop, 0, m_pPlayer->pev->origin, m_pPlayer->pev->angles, 0.0, 0.0,
-		static_cast<int>(bMakeNoise), 0, 0, 0);
+	
+	m_pPlayer->PlaybackEvent(m_usEgonStop, 0.0F, 0.0F,
+		static_cast<int>(bMakeNoise), 0, 0, 0, FEV_GLOBAL | FEV_RELIABLE);
 
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2.0;
 

--- a/dlls/gauss.cpp
+++ b/dlls/gauss.cpp
@@ -189,7 +189,7 @@ void CGauss::SecondaryAttack()
 		m_pPlayer->m_flStartCharge = gpGlobals->time;
 		m_pPlayer->m_flAmmoStartCharge = UTIL_WeaponTimeBase() + GetFullChargeTime();
 
-		PLAYBACK_EVENT_FULL(FEV_NOTHOST, m_pPlayer->edict(), m_usGaussSpin, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, 110, 0, 0, 0);
+		m_pPlayer->PlaybackEvent(m_usGaussSpin, 0.0F, 0.0F, 110);
 
 		m_iSoundState = SND_CHANGE_PITCH;
 	}
@@ -250,7 +250,7 @@ void CGauss::SecondaryAttack()
 		if (m_iSoundState == 0)
 			ALERT(at_console, "sound state %d\n", m_iSoundState);
 
-		PLAYBACK_EVENT_FULL(FEV_NOTHOST, m_pPlayer->edict(), m_usGaussSpin, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, pitch, 0, (m_iSoundState == SND_CHANGE_PITCH) ? 1 : 0, 0);
+		m_pPlayer->PlaybackEvent(m_usGaussSpin, 0.0F, 0.0F, pitch, 0, m_iSoundState == SND_CHANGE_PITCH ? 1 : 0);
 
 		m_iSoundState = SND_CHANGE_PITCH; // hack for going through level transitions
 
@@ -369,7 +369,7 @@ void CGauss::Fire(Vector vecOrigSrc, Vector vecDir, float flDamage)
 #endif
 
 	// The main firing event is sent unreliably so it won't be delayed.
-	PLAYBACK_EVENT_FULL(FEV_NOTHOST, m_pPlayer->edict(), m_usGaussFire, 0.0, m_pPlayer->pev->origin, m_pPlayer->pev->angles, flDamage, 0.0, 0, 0, m_fPrimaryFire ? 1 : 0, 0);
+	m_pPlayer->PlaybackEvent(m_usGaussFire, flDamage, 0.0F, 0, 0, static_cast<int>(m_fPrimaryFire), 0, FEV_NOTHOST, true);
 
 	SendStopEvent(false);
 
@@ -599,7 +599,7 @@ void CGauss::SendStopEvent(bool sendToHost)
 		flags |= FEV_NOTHOST;
 	}
 
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usGaussFire, 0.01, m_pPlayer->pev->origin, m_pPlayer->pev->angles, 0.0, 0.0, 0, 0, 0, 1);
+	m_pPlayer->PlaybackEvent(m_usGaussFire, 0.0F, 0.0F, 0, 0, 0, 1, flags, true, 0.01F);
 }
 
 

--- a/dlls/glock.cpp
+++ b/dlls/glock.cpp
@@ -105,14 +105,6 @@ void CGlock::GlockFire(float flSpread, float flCycleTime, bool fUseAutoAim)
 
 	m_pPlayer->pev->effects = (int)(m_pPlayer->pev->effects) | EF_MUZZLEFLASH;
 
-	int flags;
-
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
 	// player "shoot" animation
 	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
 
@@ -144,7 +136,7 @@ void CGlock::GlockFire(float flSpread, float flCycleTime, bool fUseAutoAim)
 	Vector vecDir;
 	vecDir = m_pPlayer->FireBulletsPlayer(1, vecSrc, vecAiming, Vector(flSpread, flSpread, flSpread), 8192, BULLET_PLAYER_9MM, 0, 0, m_pPlayer->pev, m_pPlayer->random_seed);
 
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), fUseAutoAim ? m_usFireGlock1 : m_usFireGlock2, 0.0, g_vecZero, g_vecZero, vecDir.x, vecDir.y, 0, 0, (m_iClip == 0) ? 1 : 0, 0);
+	m_pPlayer->PlaybackEvent(fUseAutoAim ? m_usFireGlock1 : m_usFireGlock2, vecDir.x, vecDir.y, 0, 0, m_iClip == 0 ? 1 : 0);
 
 	m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(flCycleTime);
 

--- a/dlls/hornetgun.cpp
+++ b/dlls/hornetgun.cpp
@@ -143,16 +143,7 @@ void CHgun::PrimaryAttack()
 	m_pPlayer->m_iWeaponVolume = QUIET_GUN_VOLUME;
 	m_pPlayer->m_iWeaponFlash = DIM_GUN_FLASH;
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usHornetFire, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, 0, 0, 0, 0);
-
-
+	m_pPlayer->PlaybackEvent(m_usHornetFire);
 
 	// player "shoot" animation
 	m_pPlayer->SetAnimation(PLAYER_ATTACK1);
@@ -234,15 +225,7 @@ void CHgun::SecondaryAttack()
 	m_flRechargeTime = gpGlobals->time + GetRechargeTime();
 #endif
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usHornetFire, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, 0, 0, 0, 0);
-
+	m_pPlayer->PlaybackEvent(m_usHornetFire);
 
 	m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]--;
 	m_pPlayer->m_iWeaponVolume = NORMAL_GUN_VOLUME;

--- a/dlls/mp5.cpp
+++ b/dlls/mp5.cpp
@@ -141,14 +141,7 @@ void CMP5::PrimaryAttack()
 		vecDir = m_pPlayer->FireBulletsPlayer(1, vecSrc, vecAiming, VECTOR_CONE_3DEGREES, 8192, BULLET_PLAYER_MP5, 2, 0, m_pPlayer->pev, m_pPlayer->random_seed);
 	}
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usMP5, 0.0, g_vecZero, g_vecZero, vecDir.x, vecDir.y, 0, 0, 0, 0);
+	m_pPlayer->PlaybackEvent(m_usMP5, vecDir.x, vecDir.y);
 
 	if (0 == m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		// HEV suit - indicate out of ammo condition
@@ -198,14 +191,7 @@ void CMP5::SecondaryAttack()
 		m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16,
 		gpGlobals->v_forward * 800);
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT(flags, m_pPlayer->edict(), m_usMP52);
+	m_pPlayer->PlaybackEvent(m_usMP52);
 
 	m_flNextPrimaryAttack = GetNextAttackDelay(1);
 	m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 1;

--- a/dlls/plats.cpp
+++ b/dlls/plats.cpp
@@ -1112,8 +1112,7 @@ void CFuncTrackTrain::StopSound()
 
 		us_encode = us_sound;
 
-		PLAYBACK_EVENT_FULL(FEV_RELIABLE | FEV_UPDATE, edict(), m_usAdjustPitch, 0.0,
-			g_vecZero, g_vecZero, 0.0, 0.0, us_encode, 0, 1, 0);
+		PlaybackEvent(m_usAdjustPitch, 0.0F, 0.0F, us_encode, 0, 1, 0, FEV_RELIABLE | FEV_UPDATE);
 
 		/*
 		STOP_SOUND(ENT(pev), CHAN_STATIC, (char*)STRING(pev->noise));
@@ -1162,8 +1161,7 @@ void CFuncTrackTrain::UpdateSound()
 
 		us_encode = us_sound | us_pitch | us_volume;
 
-		PLAYBACK_EVENT_FULL(FEV_RELIABLE | FEV_UPDATE, edict(), m_usAdjustPitch, 0.0,
-			g_vecZero, g_vecZero, 0.0, 0.0, us_encode, 0, 0, 0);
+		PlaybackEvent(m_usAdjustPitch, 0.0F, 0.0F, us_encode, 0, 0, 0, FEV_RELIABLE | FEV_UPDATE);
 	}
 }
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4913,6 +4913,31 @@ void CBasePlayer::SetPrefsFromUserinfo(char* infobuffer)
 	}
 }
 
+void CBasePlayer::PlaybackEvent(
+	const unsigned short usEventIndex,
+	const float fparam1,
+	const float fparam2,
+	const int iparam1,
+	const int iparam2,
+	const int bparam1,
+	const int bparam2,
+	const int afFlags,
+	const bool bSendPosition,
+	const float flDelay)
+{
+	CBaseEntity::PlaybackEvent(
+		usEventIndex,
+		fparam1,
+		fparam2,
+		iparam1,
+		iparam2,
+		bparam1,
+		bparam2,
+		afFlags,
+		bSendPosition || (afFlags & FEV_RELIABLE) != 0,
+		flDelay);
+}
+
 //=========================================================
 // Dead HEV suit prop
 //=========================================================

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -356,6 +356,22 @@ public:
 
 	//True if the player is currently spawning.
 	bool m_bIsSpawning = false;
+
+	void PlaybackEvent(
+		const unsigned short usEventIndex,
+		const float fparam1 = 0.0F,
+		const float fparam2 = 0.0F,
+		const int iparam1 = 0,
+		const int iparam2 = 0,
+		const int bparam1 = 0,
+		const int bparam2 = 0,
+#if defined(CLIENT_WEAPONS)
+		const int afFlags = FEV_NOTHOST,
+#else
+		const int afFlags = 0,
+#endif
+		const bool bSendPosition = false,
+		const float flDelay = 0.0F) override;
 };
 
 inline void CBasePlayer::SetWeaponBit(int id)

--- a/dlls/python.cpp
+++ b/dlls/python.cpp
@@ -169,14 +169,7 @@ void CPython::PrimaryAttack()
 	Vector vecDir;
 	vecDir = m_pPlayer->FireBulletsPlayer(1, vecSrc, vecAiming, VECTOR_CONE_1DEGREES, 8192, BULLET_PLAYER_357, 0, 0, m_pPlayer->pev, m_pPlayer->random_seed);
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usFirePython, 0.0, g_vecZero, g_vecZero, vecDir.x, vecDir.y, 0, 0, 0, 0);
+	m_pPlayer->PlaybackEvent(m_usFirePython, vecDir.x, vecDir.y);
 
 	if (0 == m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		// HEV suit - indicate out of ammo condition

--- a/dlls/rpg.cpp
+++ b/dlls/rpg.cpp
@@ -480,14 +480,7 @@ void CRpg::PrimaryAttack()
 		// firing RPG no longer turns on the designator. ALT fire is a toggle switch for the LTD.
 		// Ken signed up for this as a global change (sjb)
 
-		int flags;
-#if defined(CLIENT_WEAPONS)
-		flags = FEV_NOTHOST;
-#else
-		flags = 0;
-#endif
-
-		PLAYBACK_EVENT(flags, m_pPlayer->edict(), m_usRpg);
+		m_pPlayer->PlaybackEvent(m_usRpg);
 
 		m_iClip--;
 

--- a/dlls/shotgun.cpp
+++ b/dlls/shotgun.cpp
@@ -113,14 +113,6 @@ void CShotgun::PrimaryAttack()
 
 	m_iClip--;
 
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-
 	m_pPlayer->pev->effects = (int)(m_pPlayer->pev->effects) | EF_MUZZLEFLASH;
 
 	Vector vecSrc = m_pPlayer->GetGunPosition();
@@ -142,8 +134,7 @@ void CShotgun::PrimaryAttack()
 		vecDir = m_pPlayer->FireBulletsPlayer(6, vecSrc, vecAiming, VECTOR_CONE_10DEGREES, 2048, BULLET_PLAYER_BUCKSHOT, 0, 0, m_pPlayer->pev, m_pPlayer->random_seed);
 	}
 
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usSingleFire, 0.0, g_vecZero, g_vecZero, vecDir.x, vecDir.y, 0, 0, 0, 0);
-
+	m_pPlayer->PlaybackEvent(m_usSingleFire, vecDir.x, vecDir.y);
 
 	if (0 == m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		// HEV suit - indicate out of ammo condition
@@ -184,14 +175,6 @@ void CShotgun::SecondaryAttack()
 
 	m_iClip -= 2;
 
-
-	int flags;
-#if defined(CLIENT_WEAPONS)
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
 	m_pPlayer->pev->effects = (int)(m_pPlayer->pev->effects) | EF_MUZZLEFLASH;
 
 	// player "shoot" animation
@@ -217,7 +200,7 @@ void CShotgun::SecondaryAttack()
 		vecDir = m_pPlayer->FireBulletsPlayer(12, vecSrc, vecAiming, VECTOR_CONE_10DEGREES, 2048, BULLET_PLAYER_BUCKSHOT, 0, 0, m_pPlayer->pev, m_pPlayer->random_seed);
 	}
 
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usDoubleFire, 0.0, g_vecZero, g_vecZero, vecDir.x, vecDir.y, 0, 0, 0, 0);
+	m_pPlayer->PlaybackEvent(m_usDoubleFire, vecDir.x, vecDir.y);
 
 	if (0 == m_iClip && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		// HEV suit - indicate out of ammo condition

--- a/dlls/squeakgrenade.cpp
+++ b/dlls/squeakgrenade.cpp
@@ -517,14 +517,7 @@ void CSqueak::PrimaryAttack()
 		// find place to toss monster
 		UTIL_TraceLine(trace_origin + vTraceForward * 24, trace_origin + forward * 60, dont_ignore_monsters, NULL, &tr);
 
-		int flags;
-#ifdef CLIENT_WEAPONS
-		flags = FEV_NOTHOST;
-#else
-		flags = 0;
-#endif
-
-		PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usSnarkFire, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, 0, 0, 0, 0);
+		m_pPlayer->PlaybackEvent(m_usSnarkFire);
 
 		if (tr.fAllSolid == 0 && tr.fStartSolid == 0 && tr.flFraction > 0)
 		{

--- a/dlls/tripmine.cpp
+++ b/dlls/tripmine.cpp
@@ -445,14 +445,7 @@ void CTripmine::PrimaryAttack()
 
 	UTIL_TraceLine(vecSrc, vecSrc + vecAiming * 128, dont_ignore_monsters, ENT(m_pPlayer->pev), &tr);
 
-	int flags;
-#ifdef CLIENT_WEAPONS
-	flags = FEV_NOTHOST;
-#else
-	flags = 0;
-#endif
-
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usTripFire, 0.0, g_vecZero, g_vecZero, 0.0, 0.0, 0, 0, 0, 0);
+	m_pPlayer->PlaybackEvent(m_usTripFire);
 
 	if (tr.flFraction < 1.0)
 	{

--- a/dlls/vehicle.cpp
+++ b/dlls/vehicle.cpp
@@ -307,8 +307,7 @@ void CFuncVehicle ::StopSound(void)
 
 		us_encode = us_sound;
 
-		PLAYBACK_EVENT_FULL(FEV_RELIABLE | FEV_UPDATE, edict(), m_usAdjustPitch, 0.0,
-			(float*)&g_vecZero, (float*)&g_vecZero, 0.0, 0.0, us_encode, 0, 1, 0);
+		PlaybackEvent(m_usAdjustPitch, 0.0F, 0.0F, us_encode, 0, 1, 0, FEV_RELIABLE | FEV_UPDATE);
 	}
 
 	m_soundPlaying = 0;
@@ -356,8 +355,7 @@ void CFuncVehicle ::UpdateSound(void)
 
 		us_encode = us_sound | us_pitch | us_volume;
 
-		PLAYBACK_EVENT_FULL(FEV_UPDATE, edict(), m_usAdjustPitch, 0.0,
-			(float*)&g_vecZero, (float*)&g_vecZero, 0.0, 0.0, us_encode, 0, 0, 0);
+		PlaybackEvent(m_usAdjustPitch, 0.0F, 0.0F, us_encode, 0, 0, 0, FEV_UPDATE);
 	}
 }
 


### PR DESCRIPTION
Just a bit of refactoring.

The player override will send `FEV_NOTHOST` by default if weapon prediction is enabled, and send the origin and angles if the event is flagged as `FEV_RELIABLE`.
