### PR TITLE
Create event scripts if they don't exist

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -112,7 +112,6 @@ void DLLEXPORT HUD_PlayerMove(struct playermove_s* ppmove, int server)
 
 static bool CL_InitClient()
 {
-	EV_HookEvents();
 	CL_LoadParticleMan();
 
 	if (!FileSystem_LoadFileSystem())
@@ -127,6 +126,8 @@ static bool CL_InitClient()
 			"Run this mod from its intended location\n\nThe game will now shut down", nullptr);
 		return false;
 	}
+
+	EV_HookEvents();
 
 	// get tracker interface, if any
 	return true;

--- a/cl_dll/com_weapons.cpp
+++ b/cl_dll/com_weapons.cpp
@@ -273,6 +273,5 @@ stub functions for such things as precaching.  So we don't have to modify weapon
 */
 int stub_PrecacheModel(const char* s) { return 0; }
 int stub_PrecacheSound(const char* s) { return 0; }
-unsigned short stub_PrecacheEvent(int type, const char* s) { return 0; }
 const char* stub_NameForFunction(uint32 function) { return "func"; }
 void stub_SetModel(edict_t* e, const char* m) {}

--- a/cl_dll/com_weapons.h
+++ b/cl_dll/com_weapons.h
@@ -25,7 +25,6 @@ void HUD_PlaybackEvent(int flags, const struct edict_s* pInvoker, unsigned short
 void HUD_SetMaxSpeed(const struct edict_s* ed, float speed);
 int stub_PrecacheModel(const char* s);
 int stub_PrecacheSound(const char* s);
-unsigned short stub_PrecacheEvent(int type, const char* s);
 const char* stub_NameForFunction(uint32 function);
 void stub_SetModel(struct edict_s* e, const char* m);
 

--- a/cl_dll/hl/hl_events.cpp
+++ b/cl_dll/hl/hl_events.cpp
@@ -17,6 +17,14 @@
 #include "event_api.h"
 #include "pmtrace.h"
 #include "ev_hldm.h"
+#include "filesystem_utils.h"
+
+static void Game_HookEvent(const char* const szEventName, void (*const pfnEvent)(event_args_t*))
+{
+	UTIL_CheckEventScript(szEventName);
+
+	gEngfuncs.pfnHookEvent(szEventName, pfnEvent);
+}
 
 /*
 ======================
@@ -32,24 +40,24 @@ That was what we were going to do, but we ran out of time...oh well.
 */
 void Game_HookEvents()
 {
-	gEngfuncs.pfnHookEvent("events/glock1.sc", EV_FireGlock1);
-	gEngfuncs.pfnHookEvent("events/glock2.sc", EV_FireGlock2);
-	gEngfuncs.pfnHookEvent("events/shotgun1.sc", EV_FireShotGunSingle);
-	gEngfuncs.pfnHookEvent("events/shotgun2.sc", EV_FireShotGunDouble);
-	gEngfuncs.pfnHookEvent("events/mp5.sc", EV_FireMP5);
-	gEngfuncs.pfnHookEvent("events/mp52.sc", EV_FireMP52);
-	gEngfuncs.pfnHookEvent("events/python.sc", EV_FirePython);
-	gEngfuncs.pfnHookEvent("events/gauss.sc", EV_FireGauss);
-	gEngfuncs.pfnHookEvent("events/gaussspin.sc", EV_SpinGauss);
-	gEngfuncs.pfnHookEvent("events/train.sc", EV_TrainPitchAdjust);
-	gEngfuncs.pfnHookEvent("events/vehicle.sc", EV_VehiclePitchAdjust);
-	gEngfuncs.pfnHookEvent("events/crowbar.sc", EV_Crowbar);
-	gEngfuncs.pfnHookEvent("events/crossbow1.sc", EV_FireCrossbow);
-	gEngfuncs.pfnHookEvent("events/crossbow2.sc", EV_FireCrossbow2);
-	gEngfuncs.pfnHookEvent("events/rpg.sc", EV_FireRpg);
-	gEngfuncs.pfnHookEvent("events/egon_fire.sc", EV_EgonFire);
-	gEngfuncs.pfnHookEvent("events/egon_stop.sc", EV_EgonStop);
-	gEngfuncs.pfnHookEvent("events/firehornet.sc", EV_HornetGunFire);
-	gEngfuncs.pfnHookEvent("events/tripfire.sc", EV_TripmineFire);
-	gEngfuncs.pfnHookEvent("events/snarkfire.sc", EV_SnarkFire);
+	Game_HookEvent("events/glock1.sc", EV_FireGlock1);
+	Game_HookEvent("events/glock2.sc", EV_FireGlock2);
+	Game_HookEvent("events/shotgun1.sc", EV_FireShotGunSingle);
+	Game_HookEvent("events/shotgun2.sc", EV_FireShotGunDouble);
+	Game_HookEvent("events/mp5.sc", EV_FireMP5);
+	Game_HookEvent("events/mp52.sc", EV_FireMP52);
+	Game_HookEvent("events/python.sc", EV_FirePython);
+	Game_HookEvent("events/gauss.sc", EV_FireGauss);
+	Game_HookEvent("events/gaussspin.sc", EV_SpinGauss);
+	Game_HookEvent("events/train.sc", EV_TrainPitchAdjust);
+	Game_HookEvent("events/vehicle.sc", EV_VehiclePitchAdjust);
+	Game_HookEvent("events/crowbar.sc", EV_Crowbar);
+	Game_HookEvent("events/crossbow1.sc", EV_FireCrossbow);
+	Game_HookEvent("events/crossbow2.sc", EV_FireCrossbow2);
+	Game_HookEvent("events/rpg.sc", EV_FireRpg);
+	Game_HookEvent("events/egon_fire.sc", EV_EgonFire);
+	Game_HookEvent("events/egon_stop.sc", EV_EgonStop);
+	Game_HookEvent("events/firehornet.sc", EV_HornetGunFire);
+	Game_HookEvent("events/tripfire.sc", EV_TripmineFire);
+	Game_HookEvent("events/snarkfire.sc", EV_SnarkFire);
 }

--- a/cl_dll/hl/hl_weapons.cpp
+++ b/cl_dll/hl/hl_weapons.cpp
@@ -429,7 +429,6 @@ void HUD_InitClientWeapons()
 	// Fake functions
 	g_engfuncs.pfnPrecacheModel = stub_PrecacheModel;
 	g_engfuncs.pfnPrecacheSound = stub_PrecacheSound;
-	g_engfuncs.pfnPrecacheEvent = stub_PrecacheEvent;
 	g_engfuncs.pfnNameForFunction = stub_NameForFunction;
 	g_engfuncs.pfnSetModel = stub_SetModel;
 	g_engfuncs.pfnSetClientMaxspeed = HUD_SetMaxSpeed;

--- a/game_shared/filesystem_utils.cpp
+++ b/game_shared/filesystem_utils.cpp
@@ -342,3 +342,32 @@ bool UTIL_IsValveGameDirectory()
 
 	return false;
 }
+
+bool UTIL_CheckEventScript(const char* const szEventScript)
+{
+	if (g_pFileSystem->FileExists(szEventScript))
+	{
+		return true;
+	}
+
+#ifdef CLIENT_DLL
+	gEngfuncs.Con_DPrintf("creating %s\n", szEventScript);
+#else
+	ALERT(at_console, "creating %s\n", szEventScript);
+#endif
+
+	FSFile eventScript {szEventScript, "w", "GAMECONFIG"};
+
+	if (eventScript.IsOpen())
+	{
+		return true;
+	}
+
+#ifdef CLIENT_DLL
+	gEngfuncs.Con_DPrintf("failed to create %s\n", szEventScript);
+#else
+	ALERT(at_console, "failed to create %s\n", szEventScript);
+#endif
+
+	return false;
+}

--- a/game_shared/filesystem_utils.h
+++ b/game_shared/filesystem_utils.h
@@ -114,6 +114,12 @@ bool FileSystem_WriteTextToFile(const char* fileName, const char* text, const ch
 bool UTIL_IsValveGameDirectory();
 
 /**
+ * @brief Checks if the script file exists and, if not, attempts to create it.
+ * @return @c true if the script file exists or has been created
+ */
+bool UTIL_CheckEventScript(const char* const szEventScript);
+
+/**
 *	@brief Helper class to automatically close the file handle associated with a file.
 */
 class FSFile


### PR DESCRIPTION
This is just a convenience feature for modders.

The game needs these files to exist in order to create events, so this change checks that they exist when the client is initialized. If any are missing, they will be created as blank text files.
