### PR TITLE
Verify weapon selection before switching

### DIFF
--- a/cl_dll/hl/hl_baseentity.cpp
+++ b/cl_dll/hl/hl_baseentity.cpp
@@ -256,9 +256,7 @@ void CBasePlayer::Precache() {}
 bool CBasePlayer::Save(CSave& save) { return false; }
 void CBasePlayer::RenewItems() {}
 bool CBasePlayer::Restore(CRestore& restore) { return false; }
-void CBasePlayer::SelectNextItem(int iItem) {}
 bool CBasePlayer::HasWeapons() { return false; }
-void CBasePlayer::SelectPrevItem(int iItem) {}
 bool CBasePlayer::FlashlightIsOn() { return false; }
 void CBasePlayer::FlashlightTurnOn() {}
 void CBasePlayer::FlashlightTurnOff() {}
@@ -285,7 +283,7 @@ void CBasePlayer::SetCustomDecalFrames(int nFrames) {}
 int CBasePlayer::GetCustomDecalFrames() { return -1; }
 void CBasePlayer::DropPlayerItem(char* pszItemName) {}
 bool CBasePlayer::HasPlayerItem(CBasePlayerItem* pCheckItem) { return false; }
-bool CBasePlayer::SwitchWeapon(CBasePlayerItem* pWeapon) { return false; }
+void CBasePlayer::SelectItem(const char* pstr) {}
 Vector CBasePlayer::GetGunPosition() { return g_vecZero; }
 const char* CBasePlayer::TeamID() { return ""; }
 int CBasePlayer::GiveAmmo(int iCount, const char* szName, int iMax) { return 0; }
@@ -322,7 +320,6 @@ void CBasePlayerItem::AttachToPlayer(CBasePlayer* pPlayer) {}
 bool CBasePlayerWeapon::AddDuplicate(CBasePlayerItem* pOriginal) { return false; }
 void CBasePlayerWeapon::AddToPlayer(CBasePlayer* pPlayer) {}
 bool CBasePlayerWeapon::UpdateClientData(CBasePlayer* pPlayer) { return false; }
-bool CBasePlayerWeapon::IsUseable() { return true; }
 int CBasePlayerWeapon::PrimaryAmmoIndex() { return m_iPrimaryAmmoType; }
 int CBasePlayerWeapon::SecondaryAmmoIndex() { return m_iSecondaryAmmoType; }
 void CBasePlayerAmmo::Spawn() {}

--- a/cl_dll/hl/hl_weapons.cpp
+++ b/cl_dll/hl/hl_weapons.cpp
@@ -160,11 +160,8 @@ CBasePlayerWeapon:: DefaultDeploy
 
 =====================
 */
-bool CBasePlayerWeapon::DefaultDeploy(const char* szViewModel, const char* szWeaponModel, int iAnim, const char* szAnimExt, int body)
+void CBasePlayerWeapon::DefaultDeploy(const char* szViewModel, const char* szWeaponModel, int iAnim, const char* szAnimExt, int body)
 {
-	if (!CanDeploy())
-		return false;
-
 	gEngfuncs.CL_LoadModel(szViewModel, &m_pPlayer->pev->viewmodel);
 
 	SendWeaponAnim(iAnim, body);
@@ -172,7 +169,6 @@ bool CBasePlayerWeapon::DefaultDeploy(const char* szViewModel, const char* szWea
 	g_irunninggausspred = false;
 	m_pPlayer->m_flNextAttack = 0.5;
 	m_flTimeWeaponIdle = 1.0;
-	return true;
 }
 
 /*
@@ -254,39 +250,6 @@ Vector CBaseEntity::FireBulletsPlayer(unsigned int cShots, Vector vecSrc, Vector
 	}
 
 	return Vector(x * vecSpread.x, y * vecSpread.y, 0.0);
-}
-
-/*
-=====================
-CBasePlayer::SelectItem
-
-  Switch weapons
-=====================
-*/
-void CBasePlayer::SelectItem(const char* pstr)
-{
-	if (!pstr)
-		return;
-
-	CBasePlayerItem* pItem = NULL;
-
-	if (!pItem)
-		return;
-
-
-	if (pItem == m_pActiveItem)
-		return;
-
-	if (m_pActiveItem)
-		m_pActiveItem->Holster();
-
-	m_pLastItem = m_pActiveItem;
-	m_pActiveItem = pItem;
-
-	if (m_pActiveItem)
-	{
-		m_pActiveItem->Deploy();
-	}
 }
 
 /*
@@ -721,25 +684,10 @@ void HUD_WeaponsPostThink(local_state_s* from, local_state_s* to, usercmd_t* cmd
 		// Switched to a different weapon?
 		if (from->weapondata[cmd->weaponselect].m_iId == cmd->weaponselect)
 		{
-			CBasePlayerWeapon* pNew = g_pWpns[cmd->weaponselect];
-			if (pNew && (pNew != pWeapon))
-			{
-				// Put away old weapon
-				if (player.m_pActiveItem)
-					player.m_pActiveItem->Holster();
+			// Update weapon id so we can predict things correctly.
+			player.SelectItem(g_pWpns[cmd->weaponselect]);
 
-				player.m_pLastItem = player.m_pActiveItem;
-				player.m_pActiveItem = pNew;
-
-				// Deploy new weapon
-				if (player.m_pActiveItem)
-				{
-					player.m_pActiveItem->Deploy();
-				}
-
-				// Update weapon id so we can predict things correctly.
-				to->client.m_iId = cmd->weaponselect;
-			}
+			to->client.m_iId = player.m_pActiveItem != nullptr ? player.m_pActiveItem->m_iId : WEAPON_NONE;
 		}
 	}
 

--- a/dlls/crossbow.cpp
+++ b/dlls/crossbow.cpp
@@ -267,11 +267,14 @@ bool CCrossbow::GetItemInfo(ItemInfo* p)
 }
 
 
-bool CCrossbow::Deploy()
+void CCrossbow::Deploy()
 {
 	if (0 != m_iClip)
-		return DefaultDeploy("models/v_crossbow.mdl", "models/p_crossbow.mdl", CROSSBOW_DRAW1, "bow");
-	return DefaultDeploy("models/v_crossbow.mdl", "models/p_crossbow.mdl", CROSSBOW_DRAW2, "bow");
+	{
+		DefaultDeploy("models/v_crossbow.mdl", "models/p_crossbow.mdl", CROSSBOW_DRAW1, "bow");
+		return;
+	}
+	DefaultDeploy("models/v_crossbow.mdl", "models/p_crossbow.mdl", CROSSBOW_DRAW2, "bow");
 }
 
 void CCrossbow::Holster()

--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -70,9 +70,9 @@ bool CCrowbar::GetItemInfo(ItemInfo* p)
 
 
 
-bool CCrowbar::Deploy()
+void CCrowbar::Deploy()
 {
-	return DefaultDeploy("models/v_crowbar.mdl", "models/p_crowbar.mdl", CROWBAR_DRAW, "crowbar");
+	DefaultDeploy("models/v_crowbar.mdl", "models/p_crowbar.mdl", CROWBAR_DRAW, "crowbar");
 }
 
 void CCrowbar::Holster()

--- a/dlls/egon.cpp
+++ b/dlls/egon.cpp
@@ -71,11 +71,11 @@ void CEgon::Precache()
 }
 
 
-bool CEgon::Deploy()
+void CEgon::Deploy()
 {
 	m_deployed = false;
 	m_fireState = FIRE_OFF;
-	return DefaultDeploy("models/v_egon.mdl", "models/p_egon.mdl", EGON_DRAW, "egon");
+	DefaultDeploy("models/v_egon.mdl", "models/p_egon.mdl", EGON_DRAW, "egon");
 }
 
 void CEgon::Holster()

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -61,12 +61,9 @@ CBasePlayerItem* CGameRules::FindNextBestWeapon(CBasePlayer* pPlayer, CBasePlaye
 			if (pCheck->iWeight() > -1 && pCheck->iWeight() == currentWeight)
 			{
 				// this weapon is from the same category.
-				if (pCheck->CanDeploy())
+				if (pPlayer->CanSelectItem(pCheck))
 				{
-					if (pPlayer->SwitchWeapon(pCheck))
-					{
-						return pCheck;
-					}
+					return pCheck;
 				}
 			}
 			else if (pCheck->iWeight() > iBestWeight)
@@ -75,7 +72,7 @@ CBasePlayerItem* CGameRules::FindNextBestWeapon(CBasePlayer* pPlayer, CBasePlaye
 				// we keep updating the 'best' weapon just in case we can't find a weapon of the same weight
 				// that the player was using. This will end up leaving the player with his heaviest-weighted
 				// weapon.
-				if (pCheck->CanDeploy())
+				if (pPlayer->CanSelectItem(pCheck))
 				{
 					// if this weapon is useable, flag it as the best
 					iBestWeight = pCheck->iWeight();

--- a/dlls/gauss.cpp
+++ b/dlls/gauss.cpp
@@ -95,10 +95,10 @@ bool CGauss::GetItemInfo(ItemInfo* p)
 	return true;
 }
 
-bool CGauss::Deploy()
+void CGauss::Deploy()
 {
 	m_pPlayer->m_flPlayAftershock = 0.0;
-	return DefaultDeploy("models/v_gauss.mdl", "models/p_gauss.mdl", GAUSS_DRAW, "gauss");
+	DefaultDeploy("models/v_gauss.mdl", "models/p_gauss.mdl", GAUSS_DRAW, "gauss");
 }
 
 void CGauss::Holster()

--- a/dlls/glock.cpp
+++ b/dlls/glock.cpp
@@ -72,10 +72,10 @@ bool CGlock::GetItemInfo(ItemInfo* p)
 	return true;
 }
 
-bool CGlock::Deploy()
+void CGlock::Deploy()
 {
 	// pev->body = 1;
-	return DefaultDeploy("models/v_9mmhandgun.mdl", "models/p_9mmhandgun.mdl", GLOCK_DRAW, "onehanded");
+	DefaultDeploy("models/v_9mmhandgun.mdl", "models/p_9mmhandgun.mdl", GLOCK_DRAW, "onehanded");
 }
 
 void CGlock::SecondaryAttack()

--- a/dlls/h_cycler.cpp
+++ b/dlls/h_cycler.cpp
@@ -308,7 +308,7 @@ public:
 
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 	int m_iszModel;
 	int m_iModel;
@@ -333,13 +333,12 @@ void CWeaponCycler::Spawn()
 
 
 
-bool CWeaponCycler::Deploy()
+void CWeaponCycler::Deploy()
 {
 	m_pPlayer->pev->viewmodel = m_iszModel;
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 1.0;
 	SendWeaponAnim(0);
 	m_iClip = 0;
-	return true;
 }
 
 

--- a/dlls/handgrenade.cpp
+++ b/dlls/handgrenade.cpp
@@ -66,10 +66,10 @@ bool CHandGrenade::GetItemInfo(ItemInfo* p)
 }
 
 
-bool CHandGrenade::Deploy()
+void CHandGrenade::Deploy()
 {
 	m_flReleaseThrow = -1;
-	return DefaultDeploy("models/v_grenade.mdl", "models/p_grenade.mdl", HANDGRENADE_DRAW, "crowbar");
+	DefaultDeploy("models/v_grenade.mdl", "models/p_grenade.mdl", HANDGRENADE_DRAW, "crowbar");
 }
 
 bool CHandGrenade::CanHolster()

--- a/dlls/hornetgun.cpp
+++ b/dlls/hornetgun.cpp
@@ -101,9 +101,9 @@ bool CHgun::GetItemInfo(ItemInfo* p)
 }
 
 
-bool CHgun::Deploy()
+void CHgun::Deploy()
 {
-	return DefaultDeploy("models/v_hgun.mdl", "models/p_hgun.mdl", HGUN_UP, "hive");
+	DefaultDeploy("models/v_hgun.mdl", "models/p_hgun.mdl", HGUN_UP, "hive");
 }
 
 void CHgun::Holster()

--- a/dlls/mp5.cpp
+++ b/dlls/mp5.cpp
@@ -88,9 +88,9 @@ bool CMP5::GetItemInfo(ItemInfo* p)
 	return true;
 }
 
-bool CMP5::Deploy()
+void CMP5::Deploy()
 {
-	return DefaultDeploy("models/v_9mmAR.mdl", "models/p_9mmAR.mdl", MP5_DEPLOY, "mp5");
+	DefaultDeploy("models/v_9mmAR.mdl", "models/p_9mmAR.mdl", MP5_DEPLOY, "mp5");
 }
 
 

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -279,22 +279,10 @@ bool CHalfLifeMultiplay::IsCoOp()
 //=========================================================
 bool CHalfLifeMultiplay::FShouldSwitchWeapon(CBasePlayer* pPlayer, CBasePlayerItem* pWeapon)
 {
-	if (!pWeapon->CanDeploy())
-	{
-		// that weapon can't deploy anyway.
-		return false;
-	}
-
-	if (!pPlayer->m_pActiveItem)
+	if (pPlayer->m_pActiveItem == nullptr)
 	{
 		// player doesn't have an active item!
 		return true;
-	}
-
-	if (!pPlayer->m_pActiveItem->CanHolster())
-	{
-		// can't put away the active item.
-		return false;
 	}
 
 	//Never switch

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -235,7 +235,9 @@ public:
 	void RenewItems();
 	void PackDeadPlayerItems();
 	void RemoveAllItems(bool removeSuit);
-	bool SwitchWeapon(CBasePlayerItem* pWeapon);
+	bool CanSelectItem(CBasePlayerItem* pItem);
+	bool SelectItem(CBasePlayerItem* pItem);
+	void SwitchWeapon(CBasePlayerItem* pWeapon);
 
 	/**
 	*	@brief Equips an appropriate weapon for the player if they don't have one equipped already.
@@ -285,8 +287,6 @@ public:
 	bool HasNamedPlayerItem(const char* pszItemName);
 	bool HasPlayerItemFromID(int nID);
 	bool HasWeapons(); // do I have ANY weapons?
-	void SelectPrevItem(int iItem);
-	void SelectNextItem(int iItem);
 	void SelectLastItem();
 	void SelectItem(const char* pstr);
 	void ItemPreFrame();

--- a/dlls/python.cpp
+++ b/dlls/python.cpp
@@ -72,7 +72,7 @@ void CPython::Precache()
 	m_usFirePython = PRECACHE_EVENT(1, "events/python.sc");
 }
 
-bool CPython::Deploy()
+void CPython::Deploy()
 {
 #ifdef CLIENT_DLL
 	if (bIsMultiplayer())
@@ -88,7 +88,7 @@ bool CPython::Deploy()
 		pev->body = 0;
 	}
 
-	return DefaultDeploy("models/v_357.mdl", "models/p_357.mdl", PYTHON_DRAW, "python", pev->body);
+	DefaultDeploy("models/v_357.mdl", "models/p_357.mdl", PYTHON_DRAW, "python", pev->body);
 }
 
 

--- a/dlls/rpg.cpp
+++ b/dlls/rpg.cpp
@@ -416,14 +416,15 @@ bool CRpg::GetItemInfo(ItemInfo* p)
 	return true;
 }
 
-bool CRpg::Deploy()
+void CRpg::Deploy()
 {
 	if (m_iClip == 0)
 	{
-		return DefaultDeploy("models/v_rpg.mdl", "models/p_rpg.mdl", RPG_DRAW_UL, "rpg");
+		DefaultDeploy("models/v_rpg.mdl", "models/p_rpg.mdl", RPG_DRAW_UL, "rpg");
+		return;
 	}
 
-	return DefaultDeploy("models/v_rpg.mdl", "models/p_rpg.mdl", RPG_DRAW1, "rpg");
+	DefaultDeploy("models/v_rpg.mdl", "models/p_rpg.mdl", RPG_DRAW1, "rpg");
 }
 
 

--- a/dlls/satchel.cpp
+++ b/dlls/satchel.cpp
@@ -290,24 +290,21 @@ bool CSatchel::CanDeploy()
 	return false;
 }
 
-bool CSatchel::Deploy()
+void CSatchel::Deploy()
 {
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 1.0;
 	//m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + UTIL_SharedRandomFloat( m_pPlayer->random_seed, 10, 15 );
 
-	bool result;
-
 	if (0 != m_chargeReady)
-		result = DefaultDeploy("models/v_satchel_radio.mdl", "models/p_satchel_radio.mdl", SATCHEL_RADIO_DRAW, "hive");
-	else
-		result = DefaultDeploy("models/v_satchel.mdl", "models/p_satchel.mdl", SATCHEL_DRAW, "trip");
-
-	if (result)
 	{
-		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2;
+		DefaultDeploy("models/v_satchel_radio.mdl", "models/p_satchel_radio.mdl", SATCHEL_RADIO_DRAW, "hive");
+	}
+	else
+	{
+		DefaultDeploy("models/v_satchel.mdl", "models/p_satchel.mdl", SATCHEL_DRAW, "trip");
 	}
 
-	return result;
+	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 2;
 }
 
 

--- a/dlls/shotgun.cpp
+++ b/dlls/shotgun.cpp
@@ -85,9 +85,9 @@ bool CShotgun::GetItemInfo(ItemInfo* p)
 
 
 
-bool CShotgun::Deploy()
+void CShotgun::Deploy()
 {
-	return DefaultDeploy("models/v_shotgun.mdl", "models/p_shotgun.mdl", SHOTGUN_DRAW, "shotgun");
+	DefaultDeploy("models/v_shotgun.mdl", "models/p_shotgun.mdl", SHOTGUN_DRAW, "shotgun");
 }
 
 void CShotgun::PrimaryAttack()

--- a/dlls/singleplay_gamerules.cpp
+++ b/dlls/singleplay_gamerules.cpp
@@ -66,15 +66,10 @@ bool CHalfLifeRules::IsCoOp()
 //=========================================================
 bool CHalfLifeRules::FShouldSwitchWeapon(CBasePlayer* pPlayer, CBasePlayerItem* pWeapon)
 {
-	if (!pPlayer->m_pActiveItem)
+	if (pPlayer->m_pActiveItem == nullptr)
 	{
 		// player doesn't have an active item!
 		return true;
-	}
-
-	if (!pPlayer->m_pActiveItem->CanHolster())
-	{
-		return false;
 	}
 
 	return true;

--- a/dlls/squeakgrenade.cpp
+++ b/dlls/squeakgrenade.cpp
@@ -450,7 +450,7 @@ bool CSqueak::GetItemInfo(ItemInfo* p)
 
 
 
-bool CSqueak::Deploy()
+void CSqueak::Deploy()
 {
 	// play hunt sound
 	float flRndSound = RANDOM_FLOAT(0, 1);
@@ -462,14 +462,9 @@ bool CSqueak::Deploy()
 
 	m_pPlayer->m_iWeaponVolume = QUIET_GUN_VOLUME;
 
-	const bool result = DefaultDeploy("models/v_squeak.mdl", "models/p_squeak.mdl", SQUEAK_UP, "squeak");
+	DefaultDeploy("models/v_squeak.mdl", "models/p_squeak.mdl", SQUEAK_UP, "squeak");
 
-	if (result)
-	{
-		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.7;
-	}
-
-	return result;
+	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.7;
 }
 
 

--- a/dlls/tripmine.cpp
+++ b/dlls/tripmine.cpp
@@ -409,10 +409,10 @@ bool CTripmine::GetItemInfo(ItemInfo* p)
 	return true;
 }
 
-bool CTripmine::Deploy()
+void CTripmine::Deploy()
 {
 	pev->body = 0;
-	return DefaultDeploy("models/v_tripmine.mdl", "models/p_tripmine.mdl", TRIPMINE_DRAW, "trip");
+	DefaultDeploy("models/v_tripmine.mdl", "models/p_tripmine.mdl", TRIPMINE_DRAW, "trip");
 }
 
 

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -790,53 +790,8 @@ bool CBasePlayerWeapon::AddSecondaryAmmo(int iCount, char* szName, int iMax)
 	return iIdAmmo > 0 ? true : false;
 }
 
-//=========================================================
-// IsUseable - this function determines whether or not a
-// weapon is useable by the player in its current state.
-// (does it have ammo loaded? do I have any ammo for the
-// weapon?, etc)
-//=========================================================
-bool CBasePlayerWeapon::IsUseable()
+void CBasePlayerWeapon::DefaultDeploy(const char* szViewModel, const char* szWeaponModel, int iAnim, const char* szAnimExt, int body)
 {
-	if (m_iClip > 0)
-	{
-		return true;
-	}
-
-	//Player has unlimited ammo for this weapon or does not use magazines
-	if (iMaxAmmo1() == WEAPON_NOCLIP)
-	{
-		return true;
-	}
-
-	if (m_pPlayer->m_rgAmmo[PrimaryAmmoIndex()] > 0)
-	{
-		return true;
-	}
-
-	if (pszAmmo2())
-	{
-		//Player has unlimited ammo for this weapon or does not use magazines
-		if (iMaxAmmo2() == WEAPON_NOCLIP)
-		{
-			return true;
-		}
-
-		if (m_pPlayer->m_rgAmmo[SecondaryAmmoIndex()] > 0)
-		{
-			return true;
-		}
-	}
-
-	// clip is empty (or nonexistant) and the player has no more ammo of this type.
-	return CanDeploy();
-}
-
-bool CBasePlayerWeapon::DefaultDeploy(const char* szViewModel, const char* szWeaponModel, int iAnim, const char* szAnimExt, int body)
-{
-	if (!CanDeploy())
-		return false;
-
 	m_pPlayer->TabulateAmmo();
 	m_pPlayer->pev->viewmodel = MAKE_STRING(szViewModel);
 	m_pPlayer->pev->weaponmodel = MAKE_STRING(szWeaponModel);
@@ -846,8 +801,6 @@ bool CBasePlayerWeapon::DefaultDeploy(const char* szViewModel, const char* szWea
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5;
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + 1.0;
 	m_flLastFireTime = 0.0;
-
-	return true;
 }
 
 bool CBasePlayerWeapon::PlayEmptySound()
@@ -1015,12 +968,9 @@ void CBasePlayerWeapon::DoRetireWeapon()
 	// first, no viewmodel at all.
 	m_pPlayer->pev->viewmodel = iStringNull;
 	m_pPlayer->pev->weaponmodel = iStringNull;
-	//m_pPlayer->pev->viewmodelindex = NULL;
-
-	g_pGameRules->GetNextBestWeapon(m_pPlayer, this);
 
 	//If we're still equipped and we couldn't switch to another weapon, dequip this one
-	if (CanHolster() && m_pPlayer->m_pActiveItem == this)
+	if (!g_pGameRules->GetNextBestWeapon(m_pPlayer, this))
 	{
 		m_pPlayer->SwitchWeapon(nullptr);
 	}

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -230,11 +230,8 @@ public:
 	void FallInit();
 	void CheckRespawn();
 	virtual bool GetItemInfo(ItemInfo* p) { return false; } // returns false if struct not filled out
-	virtual bool CanDeploy() { return true; }
-	virtual bool Deploy() // returns is deploy was successful
-	{
-		return true;
-	}
+	virtual bool CanDeploy() { return true; } // returns if deploy was successful
+	virtual void Deploy() {}
 
 	virtual bool CanHolster() { return true; } // can this weapon be put away right now?
 	virtual void Holster();
@@ -319,7 +316,7 @@ public:
 
 	bool CanDeploy() override;
 	virtual bool IsUseable();
-	bool DefaultDeploy(const char* szViewModel, const char* szWeaponModel, int iAnim, const char* szAnimExt, int body = 0);
+	void DefaultDeploy(const char* szViewModel, const char* szWeaponModel, int iAnim, const char* szAnimExt, int body = 0);
 	bool DefaultReload(int iClipSize, int iAnim, float fDelay, int body = 0);
 
 	void ItemPostFrame() override; // called each frame by the player PostThink
@@ -501,7 +498,7 @@ public:
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
 	void GlockFire(float flSpread, float flCycleTime, bool fUseAutoAim);
-	bool Deploy() override;
+	void Deploy() override;
 	void Reload() override;
 	void WeaponIdle() override;
 
@@ -547,7 +544,7 @@ public:
 
 	void PrimaryAttack() override;
 	bool Swing(bool fFirst);
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 	int m_iSwing;
 	TraceResult m_trHit;
@@ -586,7 +583,7 @@ public:
 	bool GetItemInfo(ItemInfo* p) override;
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 	void Reload() override;
 	void WeaponIdle() override;
@@ -626,7 +623,7 @@ public:
 
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Reload() override;
 	void WeaponIdle() override;
 	float m_flNextAnimTime;
@@ -674,7 +671,7 @@ public:
 	void FireSniperBolt();
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 	void Reload() override;
 	void WeaponIdle() override;
@@ -724,7 +721,7 @@ public:
 
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Reload() override;
 	void WeaponIdle() override;
 	void ItemPostFrame() override;
@@ -789,7 +786,7 @@ public:
 	int iItemSlot() override { return 4; }
 	bool GetItemInfo(ItemInfo* p) override;
 
-	bool Deploy() override;
+	void Deploy() override;
 	bool CanHolster() override;
 	void Holster() override;
 
@@ -869,7 +866,7 @@ public:
 	int iItemSlot() override { return 4; }
 	bool GetItemInfo(ItemInfo* p) override;
 
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 
 	void PrimaryAttack() override;
@@ -953,7 +950,7 @@ public:
 	int iItemSlot() override { return 4; }
 	bool GetItemInfo(ItemInfo* p) override;
 
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 
 	void UpdateEffect(const Vector& startPoint, const Vector& endPoint, float timeBlend);
@@ -1030,7 +1027,7 @@ public:
 
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	bool IsUseable() override;
 	void Holster() override;
 	void Reload() override;
@@ -1075,7 +1072,7 @@ public:
 	bool GetItemInfo(ItemInfo* p) override;
 
 	void PrimaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	bool CanHolster() override;
 	void Holster() override;
 	void WeaponIdle() override;
@@ -1125,7 +1122,7 @@ public:
 	void SecondaryAttack() override;
 	bool AddDuplicate(CBasePlayerItem* pOriginal) override;
 	bool CanDeploy() override;
-	bool Deploy() override;
+	void Deploy() override;
 	bool IsUseable() override;
 
 	void Holster() override;
@@ -1171,7 +1168,7 @@ public:
 	}
 
 	void PrimaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 	void WeaponIdle() override;
 
@@ -1208,7 +1205,7 @@ public:
 
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
-	bool Deploy() override;
+	void Deploy() override;
 	void Holster() override;
 	void WeaponIdle() override;
 	bool m_fJustThrown;


### PR DESCRIPTION
This fixes some instances where the player is able to select unusable weapons, such as using "lastinv" to select an empty weapon.

Weapon deploying can no longer bail out; All the checks are performed before the player has actually had their active item changed. This should fix the issue where the player ends up with the wrong viewmodel.
