### PR TITLE
Copy mod data using copy scripts for windows and linux

### DIFF
--- a/filecopy.bat
+++ b/filecopy.bat
@@ -2,7 +2,13 @@
 setlocal EnableDelayedExpansion
 
 rem Set this path to your mod directory. You can use environment variables to avoid hardcoding the path if your team members have different install locations.
-set mod_directory=C:/Program Files (x86)/Steam/steamapps/common/Half-Life/halflife_updated
+if NOT DEFINED HL_MOD_PATH (
+	echo hl mod path not defined >&2
+	exit /b 1
+)
+
+set mod_directory=%HL_MOD_PATH%
+set "mod_directory=%mod_directory:\=/%"
 
 rem Input paths may end with a backslash which will be interpreted as an escape character when passed into robocopy, so this needs to be escaped.
 set source=%~1
@@ -18,10 +24,16 @@ set destination=!destination:\=\\!
 
 set filename=%~3
 
+set "options=/njh /njs /ndl /nc /ns /np"
+
+if "%filename%" == "" (
+    set "options=%options% /s"
+)
+
 echo Installing "!destination!/%filename%"
 
 rem If you are having problems with this command, remove the redirect to nul part (> nul) to get error messages from robocopy.
-@robocopy "%source%" "!destination!" "%filename%" /njh /njs /ndl /nc /ns /np > nul
+@robocopy "%source%" "!destination!" "%filename%" %options% > nul
 
 rem Needed because robocopy returns a non-zero code for success which makes Visual Studio treat this as failure.
 exit /b 0

--- a/filecopy.bat
+++ b/filecopy.bat
@@ -4,7 +4,7 @@ setlocal EnableDelayedExpansion
 rem Set this path to your mod directory. You can use environment variables to avoid hardcoding the path if your team members have different install locations.
 if NOT DEFINED HL_MOD_PATH (
 	echo hl mod path not defined >&2
-	exit /b 1
+	exit /b 0
 )
 
 set mod_directory=%HL_MOD_PATH%

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -21,6 +21,12 @@ PUBLIC_SRC_DIR=$(SOURCE_DIR)/public
 
 BUILD_OBJ_DIR=$(BUILD_DIR)/obj
 
+ifeq ($(strip $(HL_MOD_PATH)),)
+$(warning HL_MOD_PATH is empty or not set)
+endif
+
+MOD_PATH=${HL_MOD_PATH}
+
 ARCH=i386
 ELF-GC-DYNSTR=./elf-gc-dynstr
 
@@ -34,9 +40,9 @@ CPP_LIB:=-L$(shell g++ -m32 -print-file-name=libstdc++.so | xargs dirname) -lstd
 ARCH_CFLAGS=-march=pentium-m -mfpmath=387 -mno-sse
 
 ifeq "$(CFG)" "release"
-	ARCH_CFLAGS+=-O3 
+	ARCH_CFLAGS+=-O3
 else
-	ARCH_CFLAGS+=-gdwarf-2 -g2 
+	ARCH_CFLAGS+=-gdwarf-2 -g2
 endif
 
 BASE_CFLAGS=-std=c++17 -fpermissive -fno-strict-aliasing -fno-exceptions -fexpensive-optimizations -Werror=return-type -w
@@ -92,3 +98,22 @@ hl: build_dir
 
 clean:
 	-rm -rf $(BUILD_OBJ_DIR)
+
+ifneq ($(strip $(MOD_PATH)),)
+DLL_DIRECTORY=$(MOD_PATH)/dlls
+CL_DIRECTORY=$(MOD_PATH)/cl_dlls
+PARENT_DIR := $(shell dirname $(CURDIR))/mod_data
+
+copy_mod_data:
+	-rsync -a --prune-empty-dirs $(PARENT_DIR)/* $(MOD_PATH)/
+
+setup_mod:
+	-mkdir -p $(DLL_DIRECTORY);
+	-mkdir -p $(CL_DIRECTORY);
+
+copydlls_to_mod:
+	-cp $(BUILD_DIR)/hl.so $(DLL_DIRECTORY)
+	-cp $(BUILD_DIR)/client.so $(CL_DIRECTORY)
+
+build_mod: clean all setup_mod copydlls_to_mod copy_mod_data
+endif

--- a/projects/vs2019/hl_cdll.vcxproj
+++ b/projects/vs2019/hl_cdll.vcxproj
@@ -76,9 +76,12 @@
       </BaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetFileName)""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetName).pdb""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""</Command>
+      <Command>
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetFileName)""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetName).pdb""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../mod_data" "" """
+      </Command>
       <Message>Installing client files</Message>
     </PostBuildEvent>
     <PostBuildEvent />
@@ -109,9 +112,12 @@ cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delt
       </BaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetFileName)""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetName).pdb""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""</Command>
+      <Command>
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetFileName)""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "cl_dlls" "$(TargetName).pdb""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../mod_data" "" """
+      </Command>
       <Message>Installing client files</Message>
     </PostBuildEvent>
     <PostBuildEvent />

--- a/projects/vs2019/hldll.vcxproj
+++ b/projects/vs2019/hldll.vcxproj
@@ -74,9 +74,12 @@
       <ModuleDefinitionFile>$(ProjectDir)..\..\dlls\hl.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetFileName)""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetName).pdb""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""</Command>
+      <Command>
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetFileName)""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetName).pdb""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../mod_data" "" """
+      </Command>
       <Message>Installing server files</Message>
     </PostBuildEvent>
     <PostBuildEvent />
@@ -105,9 +108,12 @@ cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delt
       <ModuleDefinitionFile>$(ProjectDir)..\..\dlls\hl.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetFileName)""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetName).pdb""
-cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""</Command>
+      <Command>
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetFileName)""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(OutDir)" "dlls" "$(TargetName).pdb""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../network" "" "delta.lst""
+        cmd /c ""$(ProjectDir)..\..\filecopy.bat" "$(SolutionDir)../../mod_data" "" """
+      </Command>
       <Message>Installing server files</Message>
     </PostBuildEvent>
     <PostBuildEvent />


### PR DESCRIPTION
Hello ! 

It's my first contribution in the repository and in any game dev repo, so i don't really know yet if there is some rules or guidelines for posting a PR, but here is it.

I started tinkering with the sdk for a few months now and I found that changing from multiple environment and different mod directorys is a bit tedious. Since you also have mod files for the models, models, maps, that are important for your different changes from the dlls,.I found best that you could integrate some of the mod files that you need in the same repository as the one with your engine codebase.

In the changes files i designated a folder named mod_data in the root directory but it can be anything at all. Using the filecopy and the Makefile it will also copy all the content of the mod_data directly to the half life mod path that you set in your variable environment.

I hope it can be useful for the community.