### PR TITLE
Fixes shotgun reload animation sync when reloading from 0 clip.

### DIFF
--- a/dlls/shotgun.cpp
+++ b/dlls/shotgun.cpp
@@ -276,6 +276,8 @@ void CShotgun::Reload()
 	}
 	else
 	{
+		if (m_flNextPrimaryAttack > UTIL_WeaponTimeBase())
+			return;
 		// Add them to the clip
 		m_iClip += 1;
 		m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] -= 1;


### PR DESCRIPTION
If the player reloads the shotgun from 0 ammo in the clip, the initial shell is registered at the beginning of the animation rather than at the end. This change fixes that.
<img width="1569" height="626" alt="example1" src="https://github.com/user-attachments/assets/6a8c1b15-0f54-428d-9f76-3cac0205f8d1" />
<img width="1599" height="675" alt="example2" src="https://github.com/user-attachments/assets/cc37f852-6476-4561-8ac3-5001b40c243e" />
