### PR TITLE
Fix disabled Mute button by exporting ClientFactory

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -315,6 +315,11 @@ void CL_LoadParticleMan()
 	}
 }
 
+extern "C" DLLEXPORT void* ClientFactory()
+{
+	return (void*)(Sys_GetFactoryThis());
+}
+
 extern "C" void DLLEXPORT F(void* pv)
 {
 	cldll_func_t* pcldll_func = (cldll_func_t*)pv;
@@ -362,6 +367,8 @@ extern "C" void DLLEXPORT F(void* pv)
 			HUD_DirectorMessage,
 			HUD_GetStudioModelInterface,
 			HUD_ChatInputPosition,
+	        nullptr, // pGetPlayerTeam
+            ClientFactory,
 		};
 
 	*pcldll_func = cldll_func;


### PR DESCRIPTION
The GameUI requires the `IGameClientExports` interface from the Client DLL to manage player muting (checking status and toggling block state). Previously, the GameUI could not locate this interface because the client was not exposing its interface factory.

This change:
- Exports `ClientFactory` from cdll_int.cpp to return the client's internal interface factory (`Sys_GetFactoryThis`).
- Updates the `cldll_func_t` struct to include `ClientFactory` while passing `nullptr` for `pGetPlayerTeam` to skip its implementation and maintain alignment.

See also https://github.com/ValveSoftware/halflife/issues/1641

---

`GetServerHostName` in `CClientExports` could also be updated to actually return the server's hostname to display in the Player List dialog's title, but it is not necessary for this fix.